### PR TITLE
Custom domain fetch from Openid-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ from AWSLoginHandler.flows.pkce.manager import PKCEManager
 api = FastAPI()
 
 oauth_manager = PKCEManager(
-    user_pool_domain="https://auth.bar-tech.uk",
     client_id="7ks1311iid23h0cnvg2o3i4g7k",
     userpool_id="eu-west-2_tMeCEUTj8",
 )

--- a/example/basic_fastapi_app.py
+++ b/example/basic_fastapi_app.py
@@ -9,7 +9,6 @@ from AWSLoginHandler.flows.pkce.manager import PKCEManager
 api = FastAPI()
 
 oauth_manager = PKCEManager(
-    user_pool_domain="https://auth.bar-tech.uk",
     client_id="17gabj8fffsal3lfb393cv81kc",
     userpool_id="eu-west-2_tMeCEUTj8",
 )


### PR DESCRIPTION
The user custom domain is part of the Openid configuration at .well-known/openid-configuration

With this change the used don't need to remember the cognito app configuration.

Maybe the usage of `OpenIdConnect` can help replacing some custom code from AWSLoginHandler with something like

`oidc = OpenIdConnect(openIdConnectUrl="f"https://cognito-idp.{self.region}.amazonaws.com/{self.user_pool_id}/.well-known/openid-configuration"")
`

But I'm not familiar with `fastapi.security` 